### PR TITLE
Introduce Event subclasses and typed EventProcessors

### DIFF
--- a/src/main/java/edu/mit/puzzle/cube/core/events/CompositeEventProcessor.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/events/CompositeEventProcessor.java
@@ -1,27 +1,30 @@
 package edu.mit.puzzle.cube.core.events;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 
-import java.util.List;
+import java.util.Collection;
 
-public class CompositeEventProcessor implements EventProcessor {
+public class CompositeEventProcessor implements GenericEventProcessor {
 
-    private List<EventProcessor> eventProcessors = Lists.newArrayList();
+    @SuppressWarnings("rawtypes")
+    private Multimap<Class, EventProcessor> eventProcessors = HashMultimap.create();
 
     public CompositeEventProcessor() {
 
     }
 
-    public void addEventProcessor(EventProcessor eventProcessor) {
-        this.eventProcessors.add(eventProcessor);
+    public <T extends Event> void addEventProcessor(
+            Class<T> clazz,
+            EventProcessor<T> eventProcessor
+    ) {
+        this.eventProcessors.put(clazz, eventProcessor);
     }
 
-    public void addEventProcessors(List<EventProcessor> eventProcessors) {
-        this.eventProcessors.addAll(eventProcessors);
-    }
-
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void process(Event event) {
-        for (EventProcessor eventProcessor : eventProcessors) {
+        Collection<EventProcessor> eventTypeProcessors = eventProcessors.get(event.getClass());
+        for (EventProcessor eventProcessor : eventTypeProcessors) {
             eventProcessor.process(event);
         }
     }

--- a/src/main/java/edu/mit/puzzle/cube/core/events/Event.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/events/Event.java
@@ -12,6 +12,10 @@ public class Event {
     private final String eventType;
     private final Map<String,Object> attributes;
 
+    public Event(String eventType) {
+        this(eventType, ImmutableMap.<String, Object>of());
+    }
+
     public Event(String eventType, Map<String, Object> attributes) {
         this.eventType = checkNotNull(eventType);
         this.attributes = ImmutableMap.copyOf(attributes);

--- a/src/main/java/edu/mit/puzzle/cube/core/events/EventFactory.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/events/EventFactory.java
@@ -13,9 +13,16 @@ public class EventFactory {
     public Event generate(String json) throws IOException {
         Map<String,Object> map = Maps.newHashMap(MAPPER.readValue(json, Map.class));
         String eventType = (String) map.get("eventType");
-        map.remove("eventType");
 
-        return new Event(eventType, map);
+        switch (eventType) {
+        case FullReleaseEvent.EVENT_TYPE:
+            return new FullReleaseEvent((String) map.get("runId"), (String) map.get("puzzleId"));
+        case HuntStartEvent.EVENT_TYPE:
+            return new HuntStartEvent((String) map.get("runId"));
+        default:
+            map.remove("eventType");
+            return new Event(eventType, map);
+        }
     }
 
 }

--- a/src/main/java/edu/mit/puzzle/cube/core/events/EventProcessor.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/events/EventProcessor.java
@@ -1,7 +1,7 @@
 package edu.mit.puzzle.cube.core.events;
 
-public interface EventProcessor {
+public interface EventProcessor<T extends Event> {
 
-    public void process(Event event);
+    public void process(T event);
 
 }

--- a/src/main/java/edu/mit/puzzle/cube/core/events/FullReleaseEvent.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/events/FullReleaseEvent.java
@@ -1,0 +1,25 @@
+package edu.mit.puzzle.cube.core.events;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class FullReleaseEvent extends Event {
+
+    public static final String EVENT_TYPE = "FullRelease";
+
+    private final String runId;
+    private final String puzzleId;
+
+    public FullReleaseEvent(String runId, String puzzleId) {
+        super(EVENT_TYPE);
+        this.runId = checkNotNull(runId);
+        this.puzzleId = checkNotNull(puzzleId);
+    }
+
+    public String getRunId() {
+        return runId;
+    }
+
+    public String getPuzzleId() {
+        return puzzleId;
+    }
+}

--- a/src/main/java/edu/mit/puzzle/cube/core/events/GenericEventProcessor.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/events/GenericEventProcessor.java
@@ -1,0 +1,7 @@
+package edu.mit.puzzle.cube.core.events;
+
+public interface GenericEventProcessor extends EventProcessor<Event> {
+
+    public void process(Event event);
+
+}

--- a/src/main/java/edu/mit/puzzle/cube/core/events/HuntStartEvent.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/events/HuntStartEvent.java
@@ -1,0 +1,19 @@
+package edu.mit.puzzle.cube.core.events;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class HuntStartEvent extends Event {
+
+    public static final String EVENT_TYPE = "HuntStart";
+
+    private final String runId;
+
+    public HuntStartEvent(String runId) {
+        super(EVENT_TYPE);
+        this.runId = checkNotNull(runId);
+    }
+
+    public String getRunId() {
+        return runId;
+    }
+}

--- a/src/main/java/edu/mit/puzzle/cube/core/events/SubmissionCompleteEvent.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/events/SubmissionCompleteEvent.java
@@ -1,0 +1,21 @@
+package edu.mit.puzzle.cube.core.events;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import edu.mit.puzzle.cube.core.model.Submission;
+
+public class SubmissionCompleteEvent extends Event {
+
+    public static final String EVENT_TYPE = "SubmissionComplete";
+
+    private final Submission submission;
+
+    public SubmissionCompleteEvent(Submission submission) {
+        super(EVENT_TYPE);
+        this.submission = checkNotNull(submission);
+    }
+
+    public Submission getSubmission() {
+        return submission;
+    }
+}

--- a/src/main/java/edu/mit/puzzle/cube/core/events/VisibilityChangeEvent.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/events/VisibilityChangeEvent.java
@@ -1,0 +1,21 @@
+package edu.mit.puzzle.cube.core.events;
+
+import edu.mit.puzzle.cube.core.model.Visibility;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class VisibilityChangeEvent extends Event {
+
+    public static final String EVENT_TYPE = "VisibilityChange";
+
+    private final Visibility visibility;
+
+    public VisibilityChangeEvent(Visibility visibility) {
+        super(EVENT_TYPE);
+        this.visibility = visibility;
+    }
+
+    public Visibility getVisibility() {
+        return visibility;
+    }
+}

--- a/src/main/java/edu/mit/puzzle/cube/core/model/HuntStatusStore.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/model/HuntStatusStore.java
@@ -4,8 +4,8 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.*;
 import edu.mit.puzzle.cube.core.db.ConnectionFactory;
 import edu.mit.puzzle.cube.core.db.DatabaseHelper;
-import edu.mit.puzzle.cube.core.events.Event;
-import edu.mit.puzzle.cube.core.events.EventProcessor;
+import edu.mit.puzzle.cube.core.events.GenericEventProcessor;
+import edu.mit.puzzle.cube.core.events.VisibilityChangeEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -22,12 +22,12 @@ public class HuntStatusStore {
     private final ConnectionFactory connectionFactory;
     private final Clock clock;
     private final VisibilityStatusSet visibilityStatusSet;
-    private final EventProcessor eventProcessor;
+    private final GenericEventProcessor eventProcessor;
 
     public HuntStatusStore(
         ConnectionFactory connectionFactory,
         VisibilityStatusSet visibilityStatusSet,
-        EventProcessor eventProcessor
+        GenericEventProcessor eventProcessor
     ) {
         this(connectionFactory, Clock.systemUTC(), visibilityStatusSet, eventProcessor);
     }
@@ -36,7 +36,7 @@ public class HuntStatusStore {
             ConnectionFactory connectionFactory,
             Clock clock,
             VisibilityStatusSet visibilityStatusSet,
-            EventProcessor eventProcessor
+            GenericEventProcessor eventProcessor
     ) {
         this.connectionFactory = checkNotNull(connectionFactory);
         this.clock = checkNotNull(clock);
@@ -250,12 +250,8 @@ public class HuntStatusStore {
                     "INSERT INTO visibility_history (teamId, puzzleId, status, timestamp) VALUES (?, ?, ?, ?)",
                     Lists.newArrayList(teamId, puzzleId, status, clock.instant()));
 
-            Event changeEvent = new Event(
-                    "VisibilityChange",
-                    ImmutableMap.of(
-                            "teamId", teamId,
-                            "puzzleId", puzzleId,
-                            "status", status));
+            VisibilityChangeEvent changeEvent = new VisibilityChangeEvent(
+                    new Visibility(teamId, puzzleId, status));
             eventProcessor.process(changeEvent);
 
             return true;

--- a/src/main/java/edu/mit/puzzle/cube/core/model/SubmissionStore.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/model/SubmissionStore.java
@@ -1,13 +1,12 @@
 package edu.mit.puzzle.cube.core.model;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Table;
 import edu.mit.puzzle.cube.core.db.ConnectionFactory;
 import edu.mit.puzzle.cube.core.db.DatabaseHelper;
-import edu.mit.puzzle.cube.core.events.Event;
-import edu.mit.puzzle.cube.core.events.EventProcessor;
+import edu.mit.puzzle.cube.core.events.GenericEventProcessor;
+import edu.mit.puzzle.cube.core.events.SubmissionCompleteEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -28,11 +27,11 @@ public class SubmissionStore {
 
     private final ConnectionFactory connectionFactory;
     private final Clock clock;
-    private final EventProcessor eventProcessor;
+    private final GenericEventProcessor eventProcessor;
 
     public SubmissionStore(
             ConnectionFactory connectionFactory,
-            EventProcessor eventProcessor
+            GenericEventProcessor eventProcessor
     ) {
         this(connectionFactory, Clock.systemUTC(), eventProcessor);
     }
@@ -40,7 +39,7 @@ public class SubmissionStore {
     public SubmissionStore(
             ConnectionFactory connectionFactory,
             Clock clock,
-            EventProcessor eventProcessor
+            GenericEventProcessor eventProcessor
     ) {
         this.connectionFactory = checkNotNull(connectionFactory);
         this.clock = checkNotNull(clock);
@@ -112,8 +111,7 @@ public class SubmissionStore {
 
         if (updated && status.isTerminal()) {
             Submission submission = this.getSubmission(submissionId).get();
-            eventProcessor.process(new Event("SubmissionComplete",
-                    ImmutableMap.of("submission", submission)));
+            eventProcessor.process(new SubmissionCompleteEvent(submission));
         }
 
         return updated;

--- a/src/main/java/edu/mit/puzzle/cube/core/serverresources/AbstractCubeResource.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/serverresources/AbstractCubeResource.java
@@ -3,7 +3,7 @@ package edu.mit.puzzle.cube.core.serverresources;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.mit.puzzle.cube.core.events.EventFactory;
-import edu.mit.puzzle.cube.core.events.EventProcessor;
+import edu.mit.puzzle.cube.core.events.GenericEventProcessor;
 import edu.mit.puzzle.cube.core.model.HuntStatusStore;
 import edu.mit.puzzle.cube.core.model.SubmissionStore;
 import org.restlet.data.Status;
@@ -25,7 +25,7 @@ public abstract class AbstractCubeResource extends ServerResource {
     protected SubmissionStore submissionStore;
     protected HuntStatusStore huntStatusStore;
     protected EventFactory eventFactory;
-    protected EventProcessor eventProcessor;
+    protected GenericEventProcessor eventProcessor;
 
     public AbstractCubeResource() {
     }
@@ -34,7 +34,7 @@ public abstract class AbstractCubeResource extends ServerResource {
         this.submissionStore = (SubmissionStore) getContext().getAttributes().get(SUBMISSION_STORE_KEY);
         this.huntStatusStore = (HuntStatusStore) getContext().getAttributes().get(HUNT_STATUS_STORE_KEY);
         this.eventFactory = (EventFactory) getContext().getAttributes().get(EVENT_FACTORY_KEY);
-        this.eventProcessor = (EventProcessor) getContext().getAttributes().get(EVENT_PROCESSOR_KEY);
+        this.eventProcessor = (GenericEventProcessor) getContext().getAttributes().get(EVENT_PROCESSOR_KEY);
     }
 
     @Get("json")

--- a/src/main/java/edu/mit/puzzle/cube/huntimpl/linearexample/LinearExampleHuntDefinition.java
+++ b/src/main/java/edu/mit/puzzle/cube/huntimpl/linearexample/LinearExampleHuntDefinition.java
@@ -2,6 +2,7 @@ package edu.mit.puzzle.cube.huntimpl.linearexample;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+
 import edu.mit.puzzle.cube.core.HuntDefinition;
 import edu.mit.puzzle.cube.core.events.*;
 import edu.mit.puzzle.cube.core.model.HuntStatusStore;
@@ -50,11 +51,8 @@ public class LinearExampleHuntDefinition implements HuntDefinition {
             CompositeEventProcessor eventProcessor,
             HuntStatusStore huntStatusStore
     ) {
-        eventProcessor.addEventProcessor(event -> {
-            if (!event.getEventType().equals("SubmissionComplete")) {
-                return;
-            }
-            Submission submission = (Submission) event.getAttribute("submission");
+        eventProcessor.addEventProcessor(SubmissionCompleteEvent.class, event -> {
+            Submission submission = event.getSubmission();
             if (submission.getStatus().equals(SubmissionStatus.CORRECT)) {
                 huntStatusStore.setVisibility(
                         submission.getTeamId(),
@@ -65,39 +63,28 @@ public class LinearExampleHuntDefinition implements HuntDefinition {
             }
         });
 
-        eventProcessor.addEventProcessor(event -> {
-            if (!event.getEventType().equals("FullRelease")) {
-                return;
-            }
-            String runId = (String) event.getAttribute("runId");
-            String puzzleId = (String) event.getAttribute("puzzleId");
-            for (String teamId : huntStatusStore.getTeamIds(runId)) {
+        eventProcessor.addEventProcessor(FullReleaseEvent.class, event -> {
+            for (String teamId : huntStatusStore.getTeamIds(event.getRunId())) {
                 huntStatusStore.setVisibility(
                         teamId,
-                        puzzleId,
+                        event.getPuzzleId(),
                         "UNLOCKED",
                         false
                 );
             }
         });
 
-        eventProcessor.addEventProcessor(event -> {
-            if (!event.getEventType().equals("HuntStart")) {
-                return;
-            }
-            for (String teamId : huntStatusStore.getTeamIds((String) event.getAttribute("runId"))) {
+        eventProcessor.addEventProcessor(HuntStartEvent.class, event -> {
+            for (String teamId : huntStatusStore.getTeamIds(event.getRunId())) {
                 huntStatusStore.setVisibility(teamId, "puzzle1", "UNLOCKED", false);
             }
         });
 
         for (Map.Entry<String,String> directPrereqEntry : DIRECT_UNLOCK_PREREQS.entrySet()) {
-            eventProcessor.addEventProcessor(event -> {
-                if (!event.getEventType().equals("VisibilityChange")) {
-                    return;
-                }
-                String teamId = (String) event.getAttribute("teamId");
-                String puzzleId = (String) event.getAttribute("puzzleId");
-                String status = (String) event.getAttribute("status");
+            eventProcessor.addEventProcessor(VisibilityChangeEvent.class, event -> {
+                String teamId = event.getVisibility().getTeamId();
+                String puzzleId = event.getVisibility().getPuzzleId();
+                String status = event.getVisibility().getStatus();
 
                 if (status.equals("SOLVED") && puzzleId.equals(directPrereqEntry.getKey())) {
                     huntStatusStore.setVisibility(teamId, directPrereqEntry.getValue(),

--- a/src/test/java/edu/mit/puzzle/cube/core/events/EventFactoryTest.java
+++ b/src/test/java/edu/mit/puzzle/cube/core/events/EventFactoryTest.java
@@ -10,17 +10,17 @@ public class EventFactoryTest {
 
     @Test
     public void testDeserializationWithoutAttributes() throws IOException {
-        String json = "{\"eventType\":\"HuntStart\"}";
+        String json = "{\"eventType\":\"Generic\"}";
         Event event = new EventFactory().generate(json);
-        assertEquals("HuntStart", event.getEventType());
+        assertEquals("Generic", event.getEventType());
     }
 
     @Test
     public void testDeserializationWithAttributes() throws IOException {
-        String json = "{\"eventType\":\"HuntStart\",\"runId\":\"test\"}";
+        String json = "{\"eventType\":\"Generic\",\"key\":\"value\"}";
         Event event = new EventFactory().generate(json);
-        assertEquals("HuntStart", event.getEventType());
-        assertEquals("test", event.getAttribute("runId"));
+        assertEquals("Generic", event.getEventType());
+        assertEquals("value", event.getAttribute("key"));
     }
 
 }

--- a/src/test/java/edu/mit/puzzle/cube/core/model/HuntStatusStoreTest.java
+++ b/src/test/java/edu/mit/puzzle/cube/core/model/HuntStatusStoreTest.java
@@ -5,7 +5,7 @@ import edu.mit.puzzle.cube.core.AdjustableClock;
 import edu.mit.puzzle.cube.core.db.ConnectionFactory;
 import edu.mit.puzzle.cube.core.db.InMemorySingleUnsharedConnectionFactory;
 import edu.mit.puzzle.cube.core.events.Event;
-import edu.mit.puzzle.cube.core.events.EventProcessor;
+import edu.mit.puzzle.cube.core.events.GenericEventProcessor;
 import edu.mit.puzzle.cube.modules.model.StandardVisibilityStatusSet;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +29,7 @@ public class HuntStatusStoreTest {
     private AdjustableClock clock;
     private VisibilityStatusSet visibilityStatusSet;
     private HuntStatusStore huntStatusStore;
-    private EventProcessor eventProcessor;
+    private GenericEventProcessor eventProcessor;
 
     private static String TEST_TEAM_ID = "testerteam";
     private static String TEST_PUZZLE_ID = "a_test_puzzle";
@@ -44,7 +44,7 @@ public class HuntStatusStoreTest {
                 Lists.newArrayList(TEST_TEAM_ID),
                 Lists.newArrayList(TEST_PUZZLE_ID,TEST_PUZZLE_ID_2,TEST_PUZZLE_ID_3));
         clock = new AdjustableClock(Clock.fixed(Instant.now(), ZoneId.of("UTC")));
-        eventProcessor = mock(EventProcessor.class);
+        eventProcessor = mock(GenericEventProcessor.class);
         huntStatusStore = new HuntStatusStore(connectionFactory, clock, visibilityStatusSet, eventProcessor);
     }
 

--- a/src/test/java/edu/mit/puzzle/cube/core/model/SubmissionStoreTest.java
+++ b/src/test/java/edu/mit/puzzle/cube/core/model/SubmissionStoreTest.java
@@ -5,7 +5,7 @@ import edu.mit.puzzle.cube.core.AdjustableClock;
 import edu.mit.puzzle.cube.core.db.ConnectionFactory;
 import edu.mit.puzzle.cube.core.db.InMemorySingleUnsharedConnectionFactory;
 import edu.mit.puzzle.cube.core.events.Event;
-import edu.mit.puzzle.cube.core.events.EventProcessor;
+import edu.mit.puzzle.cube.core.events.GenericEventProcessor;
 import edu.mit.puzzle.cube.modules.model.StandardVisibilityStatusSet;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,7 +26,7 @@ public class SubmissionStoreTest {
     private ConnectionFactory connectionFactory;
     private AdjustableClock clock;
     private SubmissionStore submissionStore;
-    private EventProcessor eventProcessor;
+    private GenericEventProcessor eventProcessor;
 
     private static String TEST_TEAM_ID = "testerteam";
     private static String TEST_PUZZLE_ID = "a_test_puzzle";
@@ -38,7 +38,7 @@ public class SubmissionStoreTest {
                 Lists.newArrayList(TEST_TEAM_ID),
                 Lists.newArrayList(TEST_PUZZLE_ID));
         clock = new AdjustableClock(Clock.fixed(Instant.now(), ZoneId.of("UTC")));
-        eventProcessor = mock(EventProcessor.class);
+        eventProcessor = mock(GenericEventProcessor.class);
 
         submissionStore = new SubmissionStore(connectionFactory, clock, eventProcessor);
     }


### PR DESCRIPTION
I think I succeeded in hiding the raw type ugliness in one place (CompositeEventHandler), and there's no casting.

I left the "generic" Event (with a map of keys -> Objects) in place as the base Event for now (might be nice for a hunt to be able to annotate a built-in core event with additional properties?). I'm not sure if we want to keep this or not, or make this "arbitrary key-value event" another subclass instead of the base class.