### PR TITLE
Refactor Submission and Visibility to use AutoValue and Jackson annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 target
 *.iml
+/.apt_generated/
+.factorypath

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,25 @@
         <restlet-version>2.3.4</restlet-version>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <annotationProcessors>
+                        <annotationProcessor>
+                            com.google.auto.value.processor.AutoValueProcessor
+                        </annotationProcessor>
+                    </annotationProcessors>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -30,6 +49,11 @@
         <dependency>
             <groupId>org.restlet.jse</groupId>
             <artifactId>org.restlet</artifactId>
+            <version>${restlet-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.restlet.jse</groupId>
+            <artifactId>org.restlet.ext.jackson</artifactId>
             <version>${restlet-version}</version>
         </dependency>
         <dependency>
@@ -83,6 +107,11 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.7.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.7.1-1</version>
         </dependency>
@@ -97,6 +126,18 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>2.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <version>1.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/edu/mit/puzzle/cube/core/model/HuntStatusStore.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/model/HuntStatusStore.java
@@ -79,10 +79,11 @@ public class HuntStatusStore {
 
         return resultTable.rowMap().values().stream()
                 .map(rowMap ->
-                    new Visibility(
-                            (String) rowMap.get("teamId"),
-                            (String) rowMap.get("puzzleId"),
-                            (String) rowMap.get("status"))
+                    Visibility.builder()
+                            .setTeamId((String) rowMap.get("teamId"))
+                            .setPuzzleId((String) rowMap.get("puzzleId"))
+                            .setStatus((String) rowMap.get("status"))
+                            .build()
                 )
                 .collect(Collectors.toList());
     }
@@ -263,8 +264,11 @@ public class HuntStatusStore {
                     "INSERT INTO visibility_history (teamId, puzzleId, status, timestamp) VALUES (?, ?, ?, ?)",
                     Lists.newArrayList(teamId, puzzleId, status, clock.instant()));
 
-            VisibilityChangeEvent changeEvent = new VisibilityChangeEvent(
-                    new Visibility(teamId, puzzleId, status));
+            VisibilityChangeEvent changeEvent = new VisibilityChangeEvent(Visibility.builder()
+                    .setTeamId(teamId)
+                    .setPuzzleId(puzzleId)
+                    .setStatus(status)
+                    .build());
             eventProcessor.process(changeEvent);
 
             return true;

--- a/src/main/java/edu/mit/puzzle/cube/core/model/Submission.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/model/Submission.java
@@ -1,50 +1,33 @@
 package edu.mit.puzzle.cube.core.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import edu.mit.puzzle.cube.core.db.DatabaseHelper;
-
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
 import java.time.Instant;
+import javax.annotation.Nullable;
 
-public class Submission {
-
-    private int submissionId;
-    private String teamId;
-    private String puzzleId;
-    private String submissionText;
-    private SubmissionStatus status;
-    private Instant timestamp;
-
-    public Submission(int submissionId, String teamId, String puzzleId, String submissionText, SubmissionStatus status, Instant timestamp) {
-        this.submissionId = submissionId;
-        this.teamId = teamId;
-        this.puzzleId = puzzleId;
-        this.submissionText = submissionText;
-        this.status = status;
-        this.timestamp = timestamp;
+@AutoValue
+@JsonDeserialize(builder = AutoValue_Submission.Builder.class)
+public abstract class Submission {
+    @AutoValue.Builder
+    public static abstract class Builder {
+        @Nullable @JsonProperty("submissionId") public abstract Builder setSubmissionId(Integer submissionId);
+        @Nullable @JsonProperty("teamId") public abstract Builder setTeamId(String teamId);
+        @Nullable @JsonProperty("puzzleId") public abstract Builder setPuzzleId(String puzzleId);
+        @Nullable @JsonProperty("submission") public abstract Builder setSubmission(String submission);
+        @Nullable @JsonProperty("status") public abstract Builder setStatus(SubmissionStatus status);
+        @Nullable @JsonProperty("timestamp") public abstract Builder setTimestamp(Instant timestamp);
+        public abstract Submission build();
     }
 
-    public int getSubmissionId() {
-        return submissionId;
+    public static Builder builder() {
+        return new AutoValue_Submission.Builder();
     }
 
-    public String getTeamId() {
-        return teamId;
-    }
-
-    public String getPuzzleId() {
-        return puzzleId;
-    }
-
-    public String getSubmissionText() {
-        return submissionText;
-    }
-
-    public SubmissionStatus getStatus() {
-        return status;
-    }
-
-    public Instant getTimestamp() {
-        return timestamp;
-    }
+    @Nullable @JsonProperty("submissionId") public abstract Integer getSubmissionId();
+    @Nullable @JsonProperty("teamId") public abstract String getTeamId();
+    @Nullable @JsonProperty("puzzleId") public abstract String getPuzzleId();
+    @Nullable @JsonProperty("submission") public abstract String getSubmission();
+    @Nullable @JsonProperty("status") public abstract SubmissionStatus getStatus();
+    @Nullable @JsonProperty("timestamp") public abstract Instant getTimestamp();
 }

--- a/src/main/java/edu/mit/puzzle/cube/core/model/SubmissionStore.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/model/SubmissionStore.java
@@ -47,28 +47,28 @@ public class SubmissionStore {
         this.eventProcessor = checkNotNull(eventProcessor);
     }
 
-    public boolean addSubmission(
-            String teamId,
-            String puzzleId,
-            String submissionText
-    ) {
+    public boolean addSubmission(Submission submission) {
         return DatabaseHelper.insert(
                 connectionFactory,
                 "INSERT INTO submissions (puzzleId, teamId, submission, timestamp) " +
                         "VALUES (?,?,?,?)",
-                Lists.newArrayList(puzzleId, teamId, submissionText, clock.instant())
+                Lists.newArrayList(
+                        submission.getPuzzleId(),
+                        submission.getTeamId(),
+                        submission.getSubmission(),
+                        clock.instant())
         ).isPresent();
     }
 
     private static Submission generateSubmissionObject(Map<String,Object> rowMap) {
-        return new Submission(
-                (Integer) rowMap.get("submissionId"),
-                (String) rowMap.get("teamId"),
-                (String) rowMap.get("puzzleId"),
-                (String) rowMap.get("submission"),
-                SubmissionStatus.valueOf((String) rowMap.get("status")),
-                (Instant) rowMap.get("timestamp")
-        );
+        return Submission.builder()
+                .setSubmissionId((int) rowMap.get("submissionId"))
+                .setTeamId((String) rowMap.get("teamId"))
+                .setPuzzleId((String) rowMap.get("puzzleId"))
+                .setSubmission((String) rowMap.get("submission"))
+                .setStatus(SubmissionStatus.valueOf((String) rowMap.get("status")))
+                .setTimestamp((Instant) rowMap.get("timestamp"))
+                .build();
     }
 
     public List<Submission> getAllSubmissions() {

--- a/src/main/java/edu/mit/puzzle/cube/core/model/Submissions.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/model/Submissions.java
@@ -1,0 +1,22 @@
+package edu.mit.puzzle.cube.core.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import java.util.List;
+
+@AutoValue
+@JsonDeserialize(builder = AutoValue_Submissions.Builder.class)
+public abstract class Submissions {
+	@AutoValue.Builder
+	public static abstract class Builder {
+		@JsonProperty("submissions") public abstract Builder setSubmissions(List<Submission> submissions);
+		public abstract Submissions build();
+	}
+	
+	public static Builder builder() {
+		return new AutoValue_Submissions.Builder();
+	}
+	
+	@JsonProperty("submissions") public abstract List<Submission> getSubmissions();
+}

--- a/src/main/java/edu/mit/puzzle/cube/core/model/Visibilities.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/model/Visibilities.java
@@ -1,0 +1,22 @@
+package edu.mit.puzzle.cube.core.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import java.util.List;
+
+@AutoValue
+@JsonDeserialize(builder = AutoValue_Visibilities.Builder.class)
+public abstract class Visibilities {
+	@AutoValue.Builder
+	public static abstract class Builder {
+		@JsonProperty("visibilities") public abstract Builder setVisibilities(List<Visibility> visibilities);
+		public abstract Visibilities build();
+	}
+	
+	public static Builder builder() {
+		return new AutoValue_Visibilities.Builder();
+	}
+	
+	@JsonProperty("visibilities") public abstract List<Visibility> getVisibilities();
+}

--- a/src/main/java/edu/mit/puzzle/cube/core/model/Visibility.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/model/Visibility.java
@@ -1,28 +1,25 @@
 package edu.mit.puzzle.cube.core.model;
 
-import java.time.Instant;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
 
-public class Visibility {
-
-    private String teamId;
-    private String puzzleId;
-    private String status;
-
-    public Visibility(String teamId, String puzzleId, String status) {
-        this.teamId = teamId;
-        this.puzzleId = puzzleId;
-        this.status = status;
+@AutoValue
+@JsonDeserialize(builder = AutoValue_Visibility.Builder.class)
+public abstract class Visibility {
+    @AutoValue.Builder
+    public static abstract class Builder {
+        @JsonProperty("teamId") public abstract Builder setTeamId(String teamId);
+        @JsonProperty("puzzleId") public abstract Builder setPuzzleId(String puzzleId);
+        @JsonProperty("status") public abstract Builder setStatus(String status);
+        public abstract Visibility build();
     }
 
-    public String getTeamId() {
-        return teamId;
+    public static Builder builder() {
+        return new AutoValue_Visibility.Builder();
     }
 
-    public String getPuzzleId() {
-        return puzzleId;
-    }
-
-    public String getStatus() {
-        return status;
-    }
+    @JsonProperty("teamId") public abstract String getTeamId();
+    @JsonProperty("puzzleId") public abstract String getPuzzleId();
+    @JsonProperty("status") public abstract String getStatus();
 }

--- a/src/main/java/edu/mit/puzzle/cube/core/serverresources/AbstractCubeResource.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/serverresources/AbstractCubeResource.java
@@ -1,17 +1,9 @@
 package edu.mit.puzzle.cube.core.serverresources;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.mit.puzzle.cube.core.events.Event;
-import edu.mit.puzzle.cube.core.events.EventFactory;
-import edu.mit.puzzle.cube.core.events.EventProcessor;
+import edu.mit.puzzle.cube.core.events.*;
 import edu.mit.puzzle.cube.core.model.HuntStatusStore;
 import edu.mit.puzzle.cube.core.model.SubmissionStore;
-import org.restlet.data.Status;
-import org.restlet.ext.json.JsonRepresentation;
-import org.restlet.representation.Representation;
-import org.restlet.resource.Get;
-import org.restlet.resource.Post;
 import org.restlet.resource.ServerResource;
 
 public abstract class AbstractCubeResource extends ServerResource {
@@ -37,39 +29,4 @@ public abstract class AbstractCubeResource extends ServerResource {
         this.eventFactory = (EventFactory) getContext().getAttributes().get(EVENT_FACTORY_KEY);
         this.eventProcessor = (EventProcessor<Event>) getContext().getAttributes().get(EVENT_PROCESSOR_KEY);
     }
-
-    @Get("json")
-    public Representation handleGetRequest() {
-        try {
-            String resultJson = handleGet();
-            if (resultJson != null) {
-                return new JsonRepresentation(resultJson);
-            } else {
-                return null;
-            }
-        } catch (JsonProcessingException e) {
-            getResponse().setStatus(Status.SERVER_ERROR_INTERNAL, "Internal error");
-            return null;
-        }
-    }
-
-    protected abstract String handleGet() throws JsonProcessingException;
-
-    @Post("json")
-    public Representation handlePostRequest(JsonRepresentation representation) {
-        try {
-            String resultJson = handlePost(representation);
-            if (resultJson != null) {
-                return new JsonRepresentation(resultJson);
-            } else {
-                return null;
-            }
-        } catch (JsonProcessingException e) {
-            getResponse().setStatus(Status.SERVER_ERROR_INTERNAL, "Internal error");
-            return null;
-        }
-    }
-
-    protected abstract String handlePost(JsonRepresentation representation) throws JsonProcessingException;
-
 }

--- a/src/main/java/edu/mit/puzzle/cube/core/serverresources/EventsResource.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/serverresources/EventsResource.java
@@ -6,24 +6,20 @@ import edu.mit.puzzle.cube.core.events.Event;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.restlet.ext.json.JsonRepresentation;
-
+import org.restlet.representation.Representation;
+import org.restlet.resource.Post;
 import java.io.IOException;
 
 public class EventsResource extends AbstractCubeResource {
 
-    @Override
-    protected String handleGet() throws JsonProcessingException {
-        return "";
-    }
-
-    @Override
-    protected String handlePost(JsonRepresentation representation) throws JsonProcessingException {
+    @Post
+    public Representation handlePost(JsonRepresentation representation) throws JsonProcessingException {
         try {
             JSONObject obj = representation.getJsonObject();
             Event event = eventFactory.generate(obj.toString());
 
             eventProcessor.process(event);
-            return MAPPER.writeValueAsString(ImmutableMap.of("processed",true));
+            return new JsonRepresentation(MAPPER.writeValueAsString(ImmutableMap.of("processed",true)));
 
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/edu/mit/puzzle/cube/core/serverresources/SubmissionsResource.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/serverresources/SubmissionsResource.java
@@ -2,43 +2,32 @@ package edu.mit.puzzle.cube.core.serverresources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
-import edu.mit.puzzle.cube.core.model.HuntStatusStore;
 import edu.mit.puzzle.cube.core.model.Submission;
-import edu.mit.puzzle.cube.core.model.SubmissionStore;
-import org.json.JSONException;
-import org.json.JSONObject;
+import edu.mit.puzzle.cube.core.model.Submissions;
 import org.restlet.ext.json.JsonRepresentation;
-
-import java.util.List;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.restlet.representation.Representation;
+import org.restlet.resource.Get;
+import org.restlet.resource.Post;
 
 public class SubmissionsResource extends AbstractCubeResource {
 
-    public String handleGet() throws JsonProcessingException {
-
-        List<Submission> submissions = submissionStore.getAllSubmissions();
-
-        return MAPPER.writeValueAsString(ImmutableMap.of("submissions", submissions));
+    @Get
+    public Submissions handleGet() {
+        return Submissions.builder()
+                .setSubmissions(submissionStore.getAllSubmissions())
+                .build();
     }
 
-    public String handlePost(JsonRepresentation representation) throws JsonProcessingException {
-        try {
-            JSONObject obj = representation.getJsonObject();
-            String teamId = obj.getString("teamId");
-            String puzzleId = obj.getString("puzzleId");
-            String submission = obj.getString("submission");
-
-            String visibilityStatus = huntStatusStore.getVisibility(teamId, puzzleId);
-            if (!huntStatusStore.getVisibilityStatusSet().allowsSubmissions(visibilityStatus)) {
-                return MAPPER.writeValueAsString(ImmutableMap.of("created", false));
-            }
-
-            boolean success = submissionStore.addSubmission(teamId, puzzleId, submission);
-            return MAPPER.writeValueAsString(ImmutableMap.of("created", success));
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
+    @Post
+    public Representation handlePost(Submission submission) throws JsonProcessingException {
+        String visibilityStatus = huntStatusStore.getVisibility(
+                submission.getTeamId(),
+                submission.getPuzzleId());
+        if (!huntStatusStore.getVisibilityStatusSet().allowsSubmissions(visibilityStatus)) {
+            return new JsonRepresentation(MAPPER.writeValueAsString(ImmutableMap.of("created", false)));
         }
-    }
 
+        boolean success = submissionStore.addSubmission(submission);
+        return new JsonRepresentation(MAPPER.writeValueAsString(ImmutableMap.of("created", success)));
+    }
 }

--- a/src/main/java/edu/mit/puzzle/cube/core/serverresources/TeamResource.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/serverresources/TeamResource.java
@@ -2,12 +2,10 @@ package edu.mit.puzzle.cube.core.serverresources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Maps;
-import edu.mit.puzzle.cube.core.model.HuntStatusStore;
 import org.restlet.ext.json.JsonRepresentation;
-
+import org.restlet.representation.Representation;
+import org.restlet.resource.Get;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class TeamResource extends AbstractCubeResource {
 
@@ -19,7 +17,8 @@ public class TeamResource extends AbstractCubeResource {
         return idString;
     }
 
-    public String handleGet() throws JsonProcessingException {
+    @Get
+    public Representation handleGet() throws JsonProcessingException {
         String id = getId();
         Map<String,Object> propertyMap = huntStatusStore.getTeamProperties(id);
 
@@ -27,11 +26,6 @@ public class TeamResource extends AbstractCubeResource {
         returnMap.put("teamId",id);
         returnMap.putAll(propertyMap);
 
-        return MAPPER.writeValueAsString(returnMap);
+        return new JsonRepresentation(MAPPER.writeValueAsString(returnMap));
     }
-
-    public String handlePost(JsonRepresentation representation) throws JsonProcessingException {
-        return "";
-    }
-
 }

--- a/src/main/java/edu/mit/puzzle/cube/core/serverresources/VisibilitiesResource.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/serverresources/VisibilitiesResource.java
@@ -1,29 +1,18 @@
 package edu.mit.puzzle.cube.core.serverresources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.ImmutableMap;
-import edu.mit.puzzle.cube.core.model.Visibility;
-import edu.mit.puzzle.cube.core.model.HuntStatusStore;
-import org.restlet.ext.json.JsonRepresentation;
-
-import java.util.List;
+import edu.mit.puzzle.cube.core.model.Visibilities;
+import org.restlet.resource.Get;
 import java.util.Optional;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class VisibilitiesResource extends AbstractCubeResource {
 
-    public String handleGet() throws JsonProcessingException {
+    @Get
+    public Visibilities handleGet() throws JsonProcessingException {
         Optional<String> teamId = Optional.ofNullable(getQueryValue("teamId"));
         Optional<String> puzzleId = Optional.ofNullable(getQueryValue("puzzleId"));
-
-        List<Visibility> visibilities = huntStatusStore.getExplicitVisibilities(teamId, puzzleId);
-
-        return MAPPER.writeValueAsString(ImmutableMap.of("visibilities", visibilities));
+        return Visibilities.builder()
+                .setVisibilities(huntStatusStore.getExplicitVisibilities(teamId, puzzleId))
+                .build();
     }
-
-    public String handlePost(JsonRepresentation representation) throws JsonProcessingException {
-        throw new UnsupportedOperationException();
-    }
-
 }

--- a/src/test/java/edu/mit/puzzle/cube/core/exampleruns/LinearHuntRunTest.java
+++ b/src/test/java/edu/mit/puzzle/cube/core/exampleruns/LinearHuntRunTest.java
@@ -3,6 +3,7 @@ package edu.mit.puzzle.cube.core.exampleruns;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+
 import edu.mit.puzzle.cube.core.HuntDefinition;
 import edu.mit.puzzle.cube.core.db.ConnectionFactory;
 import edu.mit.puzzle.cube.core.environments.DevelopmentEnvironment;
@@ -11,8 +12,15 @@ import edu.mit.puzzle.cube.core.events.CompositeEventProcessor;
 import edu.mit.puzzle.cube.core.events.EventFactory;
 import edu.mit.puzzle.cube.core.model.HuntStatusStore;
 import edu.mit.puzzle.cube.core.model.SubmissionStore;
-import edu.mit.puzzle.cube.core.serverresources.*;
+import edu.mit.puzzle.cube.core.serverresources.AbstractCubeResource;
+import edu.mit.puzzle.cube.core.serverresources.EventsResource;
+import edu.mit.puzzle.cube.core.serverresources.SubmissionResource;
+import edu.mit.puzzle.cube.core.serverresources.SubmissionsResource;
+import edu.mit.puzzle.cube.core.serverresources.TeamResource;
+import edu.mit.puzzle.cube.core.serverresources.VisibilitiesResource;
+import edu.mit.puzzle.cube.core.serverresources.VisibilityResource;
 import edu.mit.puzzle.cube.huntimpl.linearexample.LinearExampleHuntDefinition;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -26,6 +34,8 @@ import org.restlet.routing.Router;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
@@ -67,6 +77,8 @@ public class LinearHuntRunTest {
                         AbstractCubeResource.EVENT_PROCESSOR_KEY, eventProcessor,
                         AbstractCubeResource.EVENT_FACTORY_KEY, eventFactory
                 )));
+        ScheduledExecutorService executorService = new ScheduledThreadPoolExecutor(1);
+        when(context.getExecutorService()).thenReturn(executorService);
         Logger logger = mock(Logger.class, Mockito.RETURNS_SMART_NULLS);
         when(context.getLogger()).thenReturn(logger);
 
@@ -98,7 +110,7 @@ public class LinearHuntRunTest {
     }
 
     private JsonNode postHuntStart(String runId) throws IOException {
-        String json = String.format("{'eventType':'HuntStart','runId':'%s'}", runId);
+        String json = String.format("{\"eventType\":\"HuntStart\",\"runId\":\"%s\"}", runId);
         Representation representation = new JsonRepresentation(json);
         Request request = new Request(Method.POST, "/events", representation);
         Response response = router.handle(request);
@@ -110,7 +122,7 @@ public class LinearHuntRunTest {
     }
 
     private JsonNode postFullRelease(String runId, String puzzleId) throws IOException {
-        String json = String.format("{'eventType':'FullRelease','runId':'%s','puzzleId':'%s'}", runId, puzzleId);
+        String json = String.format("{\"eventType\":\"FullRelease\",\"runId\":\"%s\",\"puzzleId\":\"%s\"}", runId, puzzleId);
         Representation representation = new JsonRepresentation(json);
         Request request = new Request(Method.POST, "/events", representation);
         Response response = router.handle(request);
@@ -122,7 +134,7 @@ public class LinearHuntRunTest {
     }
 
     private JsonNode postNewSubmission(String teamId, String puzzleId, String submission) throws IOException {
-        String json = String.format("{'teamId':'%s','puzzleId':'%s','submission':'%s'}",
+        String json = String.format("{\"teamId\":\"%s\",\"puzzleId\":\"%s\",\"submission\":\"%s\"}",
                 teamId, puzzleId, submission);
         Representation representation = new JsonRepresentation(json);
         Request request = new Request(Method.POST, "/submissions", representation);
@@ -143,7 +155,7 @@ public class LinearHuntRunTest {
     }
 
     private JsonNode postUpdateSubmission(Integer submissionId, String status) throws IOException {
-        String json = String.format("{'status':'%s'}", status);
+        String json = String.format("{\"status\":\"%s\"}", status);
         Representation representation = new JsonRepresentation(json);
         Request request = new Request(Method.POST,
                 String.format("/submissions/%d", submissionId),

--- a/src/test/java/edu/mit/puzzle/cube/core/model/SubmissionStoreTest.java
+++ b/src/test/java/edu/mit/puzzle/cube/core/model/SubmissionStoreTest.java
@@ -45,22 +45,26 @@ public class SubmissionStoreTest {
 
     @Test
     public void testAddAndGetSingleSubmission() {
-        submissionStore.addSubmission(TEST_TEAM_ID,TEST_PUZZLE_ID,"guess1");
+        submissionStore.addSubmission(Submission.builder()
+                .setTeamId(TEST_TEAM_ID)
+                .setPuzzleId(TEST_PUZZLE_ID)
+                .setSubmission("guess1")
+                .build());
 
         List<Submission> submissions = submissionStore.getAllSubmissions();
         assertEquals(1, submissions.size());
-        assertEquals(1, submissions.get(0).getSubmissionId());
+        assertEquals(1, submissions.get(0).getSubmissionId().intValue());
         assertEquals(TEST_TEAM_ID, submissions.get(0).getTeamId());
         assertEquals(TEST_PUZZLE_ID, submissions.get(0).getPuzzleId());
-        assertEquals("guess1", submissions.get(0).getSubmissionText());
+        assertEquals("guess1", submissions.get(0).getSubmission());
         assertEquals(SubmissionStatus.getDefault(), submissions.get(0).getStatus());
         assertEquals(clock.instant(), submissions.get(0).getTimestamp());
 
         Submission submission = submissionStore.getSubmission(1).get();
-        assertEquals(1, submission.getSubmissionId());
+        assertEquals(1, submission.getSubmissionId().intValue());
         assertEquals(TEST_TEAM_ID, submission.getTeamId());
         assertEquals(TEST_PUZZLE_ID, submission.getPuzzleId());
-        assertEquals("guess1", submission.getSubmissionText());
+        assertEquals("guess1", submission.getSubmission());
         assertEquals(SubmissionStatus.getDefault(), submission.getStatus());
         assertEquals(clock.instant(), submission.getTimestamp());
 
@@ -70,19 +74,27 @@ public class SubmissionStoreTest {
     @Test
     public void testAddAndGetMultipleSubmissions() {
         Instant firstInstant = clock.instant();
-        submissionStore.addSubmission(TEST_TEAM_ID,TEST_PUZZLE_ID,"guess1");
+        submissionStore.addSubmission(Submission.builder()
+                .setTeamId(TEST_TEAM_ID)
+                .setPuzzleId(TEST_PUZZLE_ID)
+                .setSubmission("guess1")
+                .build());
 
         clock.setWrappedClock(Clock.fixed(clock.instant().plus(5, ChronoUnit.MINUTES), clock.getZone()));
         Instant secondInstant = clock.instant();
-        submissionStore.addSubmission(TEST_TEAM_ID,TEST_PUZZLE_ID, "guess2");
+        submissionStore.addSubmission(Submission.builder()
+                .setTeamId(TEST_TEAM_ID)
+                .setPuzzleId(TEST_PUZZLE_ID)
+                .setSubmission("guess2")
+                .build());
 
         List<Submission> submissions = submissionStore.getAllSubmissions();
         assertEquals(2, submissions.size());
-        assertEquals(1, submissions.get(0).getSubmissionId());
-        assertEquals("guess1", submissions.get(0).getSubmissionText());
+        assertEquals(1, submissions.get(0).getSubmissionId().intValue());
+        assertEquals("guess1", submissions.get(0).getSubmission());
         assertEquals(firstInstant, submissions.get(0).getTimestamp());
-        assertEquals(2, submissions.get(1).getSubmissionId());
-        assertEquals("guess2", submissions.get(1).getSubmissionText());
+        assertEquals(2, submissions.get(1).getSubmissionId().intValue());
+        assertEquals("guess2", submissions.get(1).getSubmission());
         assertEquals(secondInstant, submissions.get(1).getTimestamp());
 
         verifyZeroInteractions(eventProcessor);
@@ -90,7 +102,11 @@ public class SubmissionStoreTest {
 
     @Test
     public void testUpdateSubmissionStatus() {
-        submissionStore.addSubmission(TEST_TEAM_ID, TEST_PUZZLE_ID, "guess1");
+        submissionStore.addSubmission(Submission.builder()
+                .setTeamId(TEST_TEAM_ID)
+                .setPuzzleId(TEST_PUZZLE_ID)
+                .setSubmission("guess1")
+                .build());
         Submission submission = submissionStore.getSubmission(1).get();
         assertEquals(SubmissionStatus.SUBMITTED, submission.getStatus());
 


### PR DESCRIPTION
What do you think of this change? This is just part of it, the idea would be to eliminate all uses of MAPPER and introduce classes for all JSON messages (including team, events, and the little created/updated return values). The benefits I see are that the classes would precisely document the API, and referring to property names using Java method names instead of strings should be generally safer and less error prone (e.g. this let me remove several copies of the string constant "status" that were scattered around).

I think we could (and should) go further with using these objects in the HuntStatusStore and SubmissionStore interfaces as well (e.g. always prefer to pass these model objects around over raw strings when it makes sense).

The giant pile of @Nullables on Submission is unfortunate, need a better validation story there (this is needed for the moment because POST on an existing Submission only sets "status").